### PR TITLE
feat: Enable version dropdown i18n for navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -249,10 +249,6 @@ const config = {
             type: 'docsVersionDropdown',
             position: 'left',
             dropdownActiveClassDisabled: true,
-            versions: {
-              '2025-summer': {label: '2025年夏季她行活动'},
-              '2024-winter': {label: '2024年冬季她行活动'},
-            },
           },
           {
             type: 'localeDropdown',


### PR DESCRIPTION
Remove hardcoded version labels from navbar configuration to enable proper internationalization of version dropdown menu.

Changes:
- Removed hardcoded Chinese labels from docsVersionDropdown in navbar
- Version labels now automatically use i18n translations:
  * Chinese (default): Uses labels from docs plugin configuration
    - "2025年夏季她行活动" (2025-summer)
    - "2024年冬季她行活动" (2024-winter)
  * English: Uses labels from version.json translation files
    - "Summer 2025 SheCodes Program" (2025-summer)
    - "Winter 2024 SheCodes Program" (2024-winter)

Result:
Version dropdown in navbar now properly switches labels based on selected language, providing consistent bilingual user experience.

Build Status: ✅ Successful for both zh-Hans and en locales